### PR TITLE
added param for current conditions

### DIFF
--- a/app/routers/forecast.py
+++ b/app/routers/forecast.py
@@ -13,6 +13,7 @@ forecast_url = "https://marine-api.open-meteo.com/v1/marine"
 def get_forecast(
     latitude: float, 
     longitude: float, 
+    current: Union[str, None] = None,
     hourly: Union[str, None] = None, 
     daily: Union[str, None] = None,
     start_date: Union[str, None] = None,
@@ -28,6 +29,8 @@ def get_forecast(
         "timezone": timezone,
         "length_unit": length_unit
     }
+    if current:
+        params["current"] = current
     if hourly:
         params["hourly"] = hourly
     if daily:


### PR DESCRIPTION
Added a param to `/forecast` for the `current` conditions. Now we can fetch:
```
{
    "latitude": 36.958336,
    "longitude": -122.04166,
    "generationtime_ms": 0.0858306884765625,
    "utc_offset_seconds": -25200,
    "timezone": "America/Los_Angeles",
    "timezone_abbreviation": "GMT-7",
    "elevation": 0.0,
    "current_units": {
        "time": "iso8601",
        "interval": "seconds",
        "swell_wave_height": "ft",
        "swell_wave_direction": "°",
        "swell_wave_period": "s"
    },
    "current": {
        "time": "2025-06-11T09:00",
        "interval": 3600,
        "swell_wave_height": 2.034,
        "swell_wave_direction": 295,
        "swell_wave_period": 10.4
    }
}
```