### PR TITLE
install pandas & create endpoint for realtime data

### DIFF
--- a/app/classes/buoylocation.py
+++ b/app/classes/buoylocation.py
@@ -1,3 +1,45 @@
+import pandas as pd
+
+class BuoyData():
+    def __init__ (self):
+        self.location_id = None
+        self.data = None
+
+    def set_data(self, data):
+        self.data = data
+
+    def get_data(self):
+        if self.data is None:
+            self.data = pd.DataFrame()
+        return self.data
+    
+class BuoyDataBuilder():
+    def __init__(self):
+        self.base_url = 'https://www.ndbc.noaa.gov/data/realtime2/'
+        self.realtime_buoy = BuoyData()
+
+    def build(self, location_id, data):
+        self.realtime_buoy.url = self.base_url + location_id + '.txt'
+        self.realtime_buoy.location_id = location_id
+        self.realtime_buoy.set_data(self._mk_dataframe(data))
+
+        return self.realtime_buoy
+
+    def _mk_dataframe(self, data):
+        try:
+            df = pd.DataFrame([x.split() for x in data], columns=[
+                "YY", "MM", "DD", "hh", "mm", "wind_dir", "wind_speed", "gst",
+                "wave_height", "dominant_period", "avg_period", "pressure",
+                "water_temp", "air_temp", "dew_point", "visibility", "pdty", "tide", "end_of_line"
+            ])
+        except Exception as e:
+            print(f"Error creating DataFrame: {e}")
+            df = pd.DataFrame()
+
+        return df
+
+        
+
 class BuoyLocation():
     def __init__(self, buoy_location):
         self.location = buoy_location.location

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,10 +52,11 @@ MarkupSafe==2.1.2
 matplotlib==3.5.3
 mccabe==0.7.0
 node==1.2.1
-numpy==1.21.6
+numpy==2.0.2
 odict==1.9.0
 orjson==3.8.12
 packaging==23.1
+pandas==2.3.1
 passlib==1.7.4
 Pillow==9.5.0
 pipenv==2023.4.29
@@ -68,6 +69,7 @@ pyasn1==0.5.0
 pycparser==2.21
 pydantic==1.10.7
 pydantic_core==2.33.0
+PyJWT==2.10.1
 pylint==2.17.4
 pyparsing==3.0.9
 pyrsistent==0.19.3
@@ -92,6 +94,7 @@ tomli==2.0.1
 tomlkit==0.11.8
 typing-inspection==0.4.0
 typing_extensions==4.13.0
+tzdata==2025.2
 ujson==5.7.0
 urllib3==2.0.2
 uvicorn==0.22.0


### PR DESCRIPTION
Add endpoint `{{URL}}api/v1/locations/46237/realtime?limit=100&send_html=false` for fetching realtime buoy data from NOAA.

Data comes in a text file, so we're using pandas to clean it up before serving it via the API: `https://www.ndbc.noaa.gov/data/realtime2/46218.txt`

We can also return HTML which can be rendered in the client app for some nice visual data.

Returns data in the shape of 

```
    "location_id": "46237",
    "url": "https://www.ndbc.noaa.gov/data/realtime2/46237.txt",
    "data": {...},
    "html": {...}
```
