### PR TITLE
Add POST /spots endpoint with automatic slug generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Visit [http://127.0.0.1:5000/api/v1](http://127.0.0.1:5000/api/v1) for interacti
 ### Core Endpoints
 - `GET /` - Health check
 - `GET /api/v1/spots` - Get surf spots
+- `POST /api/v1/spots` - Create new surf spot (admin only)
 - `GET /api/v1/locations` - Get buoy locations
 - `GET /api/v1/forecast` - Get weather forecast
 - `GET /api/v1/weather` - Get current weather

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -85,6 +85,14 @@ class BuoyLocationLatestObservation(BaseModel):
         orm_mode = True
 
 # Spots
+class SpotLocationPost(BaseModel):
+    '''Schema for creating a new surf spot'''
+    name: str
+    timezone: str
+    latitude: float
+    longitude: float
+    subregion_name: str
+
 class SpotLocationResponse(BaseModel):
     '''Our base schema for surf spots'''
     id: int

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,6 +43,7 @@ starlette>=0.26.0,<0.48.0
 typing-inspection>=0.4.0,<1.0.0
 typing_extensions>=4.8.0,<5.0.0
 tzdata>=2023.3,<2026.0
+unidecode>=1.3.0,<2.0.0
 urllib3>=2.0.0,<3.0.0
 uvicorn>=0.22.0,<1.0.0
 yarg>=0.1.9,<1.0.0


### PR DESCRIPTION
Added `POST` to the `spots/` endpoint to create a new spot. Scripts the slug generation in the API call before committing to the database.

This endpoint will take away the need for using the old `tools/import_spot_json.py` script that required a JSON file to load and create all the spots in one go. 

We can in the future use an admin interface or script a bunch of CURLs or whatever to get the job done.