### PR TITLE
added endpoint for current hourly tides

### DIFF
--- a/app/routers/tides.py
+++ b/app/routers/tides.py
@@ -50,6 +50,62 @@ def get_closest_tide_station(lat: float, lng: float, dist: float = 50, db: Sessi
     
     return sorted_best[0]
 
+
+"""
+NOAA Tides and Currents API Documentation
+
+Base URL: https://api.tidesandcurrents.noaa.gov/api/prod/datagetter
+
+Example request:
+GET https://api.tidesandcurrents.noaa.gov/api/prod/datagetter?
+    date=today&
+    station=9414290&
+    product=water_level&
+    datum=MLLW&
+    time_zone=gmt&
+    units=english&
+    application=DataAPI_Sample&
+    format=xml
+
+Parameters:
+- station: NOAA station ID (e.g., 9414290 for San Diego)
+- product: Data type (water_level, predictions, etc.)
+- datum: Vertical reference (MLLW, NAVD88, etc.)
+- time_zone: Time zone (gmt, lst_ldt, etc.)
+- units: Measurement units (english, metric)
+- application: Application name for tracking
+- format: Response format (json, xml, csv)
+- date: Date for data (today, yesterday, YYYYMMDD)
+- begin_date/end_date: Date range for historical data
+- interval: Data interval (hilo, h, 6, etc.)
+
+Please see NOAA documentation for more details: https://api.tidesandcurrents.noaa.gov/api/prod/responseHelp.html
+"""
+@router.get("/tides/current")
+def get_current_tides(station: str, date: str = "today", product: str = "water_level", datum: str = "MLLW", time_zone: str = "gmt", units: str = "english", application: str = "surfe-diem.com", format: str = "json"):
+    '''Get the current tides for a given station'''
+    params = {
+        "station": station,
+        "product": product,
+        "datum": datum,
+        "time_zone": time_zone,
+        "units": units,
+        "application": application,
+        "format": format
+    }
+
+    if date:
+        params["date"] = date
+
+    try:
+        r = httpx.get(tides_url, params=params)
+        r.raise_for_status()
+        return r.json()
+    except httpx.RequestError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"An error occurred while requesting {exc.request.url!r}.")
+    except httpx.HTTPStatusError as exc:
+        raise HTTPException(status_code=exc.response.status_code, detail=f"something went wrong, please try again. {exc.response.reason_phrase}")
+    
 @router.get("/tides")
 def get_tides(
     station: str,

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,7 @@
 import pytest
+from unittest.mock import patch, Mock
+from fastapi.testclient import TestClient
+from app.main import app
 from app.classes.spotlocation import SpotLocation
 
 def test_spot_location_creation():
@@ -68,3 +71,124 @@ def test_buoy_location_parsing():
     # Should return [longitude, latitude]
     assert coords[0] == -121.97  # longitude
     assert coords[1] == 36.95    # latitude 
+
+def test_tides_current_endpoint_success():
+    """Test successful tides current endpoint call."""
+    with patch('httpx.get') as mock_get:
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "predictions": [
+                {"t": "2024-01-01 12:00", "v": "5.2"},
+                {"t": "2024-01-01 18:00", "v": "1.1"}
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        client = TestClient(app)
+        response = client.get("/tides/current?station=9414290&date=today")
+        
+        assert response.status_code == 200
+        assert "predictions" in response.json()
+        
+        # Verify the correct URL was called
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        assert "station=9414290" in str(call_args)
+        assert "date=today" in str(call_args)
+
+def test_tides_current_endpoint_missing_station():
+    """Test tides current endpoint with missing required station parameter."""
+    client = TestClient(app)
+    response = client.get("/tides/current")
+    
+    assert response.status_code == 422  # Validation error
+
+def test_tides_current_endpoint_http_error():
+    """Test tides current endpoint with HTTP error from NOAA API."""
+    with patch('httpx.get') as mock_get:
+        # Mock HTTP error
+        mock_get.side_effect = Exception("Connection error")
+        
+        client = TestClient(app)
+        response = client.get("/tides/current?station=9414290")
+        
+        assert response.status_code == 400
+        assert "error occurred" in response.json()["detail"]
+
+def test_tides_endpoint_with_date_range():
+    """Test tides endpoint with begin_date and end_date parameters."""
+    with patch('httpx.get') as mock_get:
+        # Mock successful response
+        mock_response = Mock()
+        mock_response.json.return_value = {
+            "predictions": [
+                {"t": "2024-01-01 12:00", "v": "5.2"},
+                {"t": "2024-01-02 12:00", "v": "5.1"}
+            ]
+        }
+        mock_response.raise_for_status.return_value = None
+        mock_get.return_value = mock_response
+        
+        client = TestClient(app)
+        response = client.get("/tides?station=9414290&begin_date=20240101&end_date=20240102")
+        
+        assert response.status_code == 200
+        assert "predictions" in response.json()
+        
+        # Verify date range parameters were passed
+        call_args = mock_get.call_args
+        assert "begin_date=20240101" in str(call_args)
+        assert "end_date=20240102" in str(call_args)
+
+def test_tides_find_closest_endpoint():
+    """Test finding closest tide station endpoint."""
+    with patch('app.routers.tides.get_db') as mock_get_db:
+        # Mock database session with sample tide stations
+        mock_db = Mock()
+        mock_stations = [
+            Mock(station_id="9414290", latitude=32.7157, longitude=-117.1617),  # San Diego
+            Mock(station_id="9410230", latitude=32.8669, longitude=-117.2567),  # La Jolla
+        ]
+        mock_db.query.return_value.all.return_value = mock_stations
+        mock_get_db.return_value = mock_db
+        
+        client = TestClient(app)
+        response = client.get("/tides/find_closest?lat=32.7157&lng=-117.1617&dist=50")
+        
+        assert response.status_code == 200
+        result = response.json()
+        assert result["station_id"] == "9414290"  # Should find San Diego station
+        assert result["distance"] < 1  # Should be very close to exact coordinates
+
+def test_tides_find_closest_no_stations():
+    """Test finding closest tide station when no stations exist."""
+    with patch('app.routers.tides.get_db') as mock_get_db:
+        # Mock empty database
+        mock_db = Mock()
+        mock_db.query.return_value.all.return_value = []
+        mock_get_db.return_value = mock_db
+        
+        client = TestClient(app)
+        response = client.get("/tides/find_closest?lat=32.7157&lng=-117.1617")
+        
+        assert response.status_code == 404
+        assert "no tide stations found" in response.json()["detail"]
+
+def test_tides_find_closest_out_of_range():
+    """Test finding closest tide station when all stations are out of range."""
+    with patch('app.routers.tides.get_db') as mock_get_db:
+        # Mock stations far from query point
+        mock_db = Mock()
+        mock_stations = [
+            Mock(station_id="9414290", latitude=40.0, longitude=-120.0),  # Far away
+        ]
+        mock_db.query.return_value.all.return_value = mock_stations
+        mock_get_db.return_value = mock_db
+        
+        client = TestClient(app)
+        response = client.get("/tides/find_closest?lat=32.7157&lng=-117.1617&dist=50")
+        
+        assert response.status_code == 404
+        assert "tide data not available" in response.json()["detail"] 


### PR DESCRIPTION
Gets current data from the tides application at NOAA:

`GET /tides/current?station=9414290&date=today&units=english`

Response: JSON data from NOAA Tides and Currents API containing tide predictions/measurements

Error Handling:
Returns 422 for missing required parameters
Returns 400 for NOAA API connection errors
Returns appropriate status codes for NOAA API errors

Use Case: Get real-time or historical tide data for surf spot analysis and forecasting

