### PR TITLE
spot ratings endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 .env
 *.db
 *.db.backup
+*.db.bak
 assets
 migration_tools
 local_utils

--- a/alembic.ini
+++ b/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = 
+sqlalchemy.url = sqlite:///./surfe-diem-api.db
 
 
 [post_write_hooks]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -10,8 +10,7 @@ from app.config import settings
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config
-config.set_main_option(
-    "sqlalchemy.url", f'postgresql+psycopg2://{settings.database_username}:{settings.database_password}@{settings.database_hostname}:{settings.database_port}/{settings.database_name}')
+
 
 # Interpret the config file for Python logging.
 # This line sets up loggers basically.

--- a/alembic/versions/spot_accuracy_rating_20250918.py
+++ b/alembic/versions/spot_accuracy_rating_20250918.py
@@ -1,0 +1,39 @@
+"""create spot_accuracy_rating table
+
+Revision ID: spot_accuracy_rating_20250918
+Revises: 
+Create Date: 2025-09-18
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'spot_accuracy_rating_20250918'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    spot_rating_enum = sa.Enum('accurate', 'not_accurate', name='spot_rating_enum')
+    spot_rating_enum.create(op.get_bind(), checkfirst=True)
+    op.create_table(
+        'spot_accuracy_rating',
+        sa.Column('id', sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column('spot_id', sa.Integer, nullable=False),
+        sa.Column('spot_slug', sa.String(length=128), nullable=False),
+        sa.Column('rating', spot_rating_enum, nullable=False),
+        sa.Column('forecast_json', sa.JSON, nullable=True),
+        sa.Column('timestamp', sa.DateTime, nullable=False),
+        sa.Column('session_id', sa.String(length=128), nullable=False),
+        sa.Column('ip_address', sa.String(length=45), nullable=False),
+        sa.Column('user_id', sa.Integer, nullable=True),
+        sa.ForeignKeyConstraint(['spot_id'], ['spots.id'], name='fk_spot_id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], name='fk_user_id'),
+        sa.UniqueConstraint('spot_id', 'session_id', 'ip_address', 'timestamp', name='uq_spot_session_ip_date')
+    )
+
+def downgrade():
+    op.drop_table('spot_accuracy_rating')
+    spot_rating_enum = sa.Enum('accurate', 'not_accurate', name='spot_rating_enum')
+    spot_rating_enum.drop(op.get_bind(), checkfirst=True)

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,7 @@
 from sqlalchemy import Column, Integer, String, Boolean, ForeignKey
 from sqlalchemy.sql import func
 from sqlalchemy.sql.sqltypes import TIMESTAMP
+from sqlalchemy import DateTime, JSON, UniqueConstraint, Enum
 from .database import Base
 
 class Test(Base):
@@ -101,3 +102,20 @@ class UserLocation(Base):
     __tablename__ = "user_location"
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), primary_key=True)
     location_id = Column(Integer, ForeignKey("buoy_location.location_id", ondelete="CASCADE"), primary_key=True)
+
+# SpotAccuracyRating model for spot_accuracy_rating table
+class SpotAccuracyRating(Base):
+    __tablename__ = "spot_accuracy_rating"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    spot_id = Column(Integer, nullable=False)
+    spot_slug = Column(String(128), nullable=False)
+    rating = Column(Enum('accurate', 'not_accurate', name='spot_rating_enum'), nullable=False)
+    forecast_json = Column(JSON, nullable=True)
+    timestamp = Column(DateTime, nullable=False)
+    session_id = Column(String(128), nullable=False)
+    ip_address = Column(String(45), nullable=False)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
+
+    __table_args__ = (
+        UniqueConstraint('spot_id', 'session_id', 'ip_address', 'timestamp', name='uq_spot_session_ip_date'),
+    )

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -216,10 +216,29 @@ class TideStationsListResponse(BaseModel):
     offset: int
 
 
-# NOAA API Response Schemas (for when we get data back)
-class NOAATidesResponse(BaseModel):
-    """Generic NOAA API response wrapper"""
-    # This will be flexible since NOAA responses vary by endpoint
-    # We'll use dict[str, Any] for now and can make more specific later
-    pass 
+
+# Spot Accuracy Rating Schemas
+from enum import Enum as PyEnum
+
+class SpotRatingEnum(PyEnum):
+    accurate = "accurate"
+    not_accurate = "not_accurate"
+
+class SpotAccuracyRatingBase(BaseModel):
+    spot_id: int
+    spot_slug: str
+    rating: SpotRatingEnum
+    forecast_json: dict
+    timestamp: datetime
+    session_id: str
+    ip_address: str
+    user_id: Optional[int] = None
+
+class SpotAccuracyRatingCreate(SpotAccuracyRatingBase):
+    pass
+
+class SpotAccuracyRatingResponse(SpotAccuracyRatingBase):
+    id: int
+    class Config:
+        orm_mode = True
     

--- a/tests/test_spot_rating.py
+++ b/tests/test_spot_rating.py
@@ -1,0 +1,316 @@
+import pytest
+from unittest.mock import patch, Mock
+from fastapi.testclient import TestClient
+from datetime import datetime, timezone, date
+from app.main import app
+from app.database import get_db
+
+class TestSpotRatingEndpoint:
+    """Test suite for the spot rating endpoint."""
+    
+    def setup_method(self):
+        """Set up test client and common test data."""
+        self.client = TestClient(app)
+        self.valid_rating_data = {
+            "spot_id": 1,
+            "spot_slug": "test-spot",
+            "rating": "accurate",
+            "forecast_json": {"wave_height": "2-3ft", "wind": "5-10mph"},
+            "timestamp": "2025-09-18T12:00:00Z",
+            "session_id": "test-session-123",
+            "ip_address": "127.0.0.1",
+            "user_id": None
+        }
+        
+    def test_rate_spot_success(self):
+        """Test successful spot rating submission."""
+        # Create a mock database session
+        mock_db = Mock()
+        
+        # Mock spot exists
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "test-spot"
+        
+        # Mock query chain for spot lookup and rating check
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_spot,  # First call: spot lookup
+            None        # Second call: existing rating check
+        ]
+        
+        # Mock successful database operations
+        mock_new_rating = Mock()
+        mock_new_rating.id = 1
+        mock_new_rating.spot_id = 1
+        mock_new_rating.spot_slug = "test-spot"
+        mock_new_rating.rating = "accurate"
+        
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+        
+        # Override the dependency
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=self.valid_rating_data,
+                cookies={"surfe-diem-session-id": "existing-session-123"}
+            )
+            
+            assert response.status_code == 200
+            
+            # Verify database operations were called
+            mock_db.add.assert_called_once()
+            mock_db.commit.assert_called_once()
+            mock_db.refresh.assert_called_once()
+        finally:
+            # Clean up dependency override
+            app.dependency_overrides.clear()
+            
+    def test_rate_spot_not_found(self):
+        """Test rating submission for non-existent spot."""
+        mock_db = Mock()
+        
+        # Mock spot doesn't exist
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/999/rating",
+                json=self.valid_rating_data
+            )
+            
+            assert response.status_code == 404
+            assert "Spot not found" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+            
+    def test_rate_spot_already_rated_today(self):
+        """Test rating submission when user already rated today."""
+        mock_db = Mock()
+        
+        # Mock spot exists
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "test-spot"
+        
+        # Mock existing rating for today
+        mock_existing_rating = Mock()
+        mock_existing_rating.id = 1
+        
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_spot,           # First call: spot lookup
+            mock_existing_rating # Second call: existing rating check
+        ]
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=self.valid_rating_data,
+                cookies={"surfe-diem-session-id": "existing-session-123"}
+            )
+            
+            assert response.status_code == 409
+            assert "You have already rated this spot today" in response.json()["detail"]
+        finally:
+            app.dependency_overrides.clear()
+        
+    def test_rate_spot_generates_session_id(self):
+        """Test that endpoint generates session ID when none provided."""
+        mock_db = Mock()
+        
+        # Mock spot exists and no existing rating
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "test-spot"
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_spot,  # First call: spot lookup
+            None        # Second call: existing rating check
+        ]
+        
+        # Mock successful database operations
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=self.valid_rating_data
+                # No session cookie provided
+            )
+            
+            assert response.status_code == 200
+            
+            # Check that session cookie was set in response
+            assert "surfe-diem-session-id" in response.cookies
+            session_id = response.cookies["surfe-diem-session-id"]
+            assert session_id.startswith("session_")
+            assert len(session_id) > 10  # Should be a UUID-based string
+        finally:
+            app.dependency_overrides.clear()
+            
+    def test_rate_spot_invalid_rating_enum(self):
+        """Test rating submission with invalid enum value."""
+        invalid_data = self.valid_rating_data.copy()
+        invalid_data["rating"] = "invalid_rating"
+        
+        response = self.client.post(
+            "/api/v1/spots/1/rating",
+            json=invalid_data
+        )
+        
+        assert response.status_code == 422  # Validation error
+        
+    def test_rate_spot_missing_required_fields(self):
+        """Test rating submission with missing required fields."""
+        incomplete_data = {
+            "spot_id": 1,
+            "rating": "accurate"
+            # Missing other required fields
+        }
+        
+        response = self.client.post(
+            "/api/v1/spots/1/rating",
+            json=incomplete_data
+        )
+        
+        assert response.status_code == 422  # Validation error
+        
+    def test_rate_spot_database_error(self):
+        """Test handling of database errors during rating submission."""
+        mock_db = Mock()
+        
+        # Mock spot exists and no existing rating
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "test-spot"
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_spot,  # First call: spot lookup
+            None        # Second call: existing rating check
+        ]
+        
+        # Mock database error on commit
+        mock_db.add.return_value = None
+        mock_db.commit.side_effect = Exception("Database connection error")
+        mock_db.rollback.return_value = None
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=self.valid_rating_data,
+                cookies={"surfe-diem-session-id": "test-session-123"}
+            )
+            
+            assert response.status_code == 500
+            assert "Failed to save rating" in response.json()["detail"]
+            
+            # Verify rollback was called
+            mock_db.rollback.assert_called_once()
+        finally:
+            app.dependency_overrides.clear()
+            
+    def test_rate_spot_uses_spot_slug_from_db(self):
+        """Test that endpoint uses spot slug from database, not request data."""
+        mock_db = Mock()
+        
+        # Mock spot with different slug than in request
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "actual-spot-slug"  # Different from request data
+        mock_db.query.return_value.filter.return_value.first.side_effect = [
+            mock_spot,  # First call: spot lookup
+            None        # Second call: existing rating check
+        ]
+        
+        # Mock successful database operations
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+        
+        # Use data with wrong slug
+        test_data = self.valid_rating_data.copy()
+        test_data["spot_slug"] = "wrong-slug-from-request"
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=test_data,
+                cookies={"surfe-diem-session-id": "test-session-123"}
+            )
+            
+            assert response.status_code == 200
+            
+            # Verify the add method was called (meaning the rating was created)
+            mock_db.add.assert_called_once()
+            
+            # The actual slug validation is in the endpoint logic - it uses spot.slug
+            # This test confirms that the endpoint accepts the request even with wrong slug
+        finally:
+            app.dependency_overrides.clear()
+            
+    def test_rate_spot_valid_enum_values(self):
+        """Test that both valid enum values are accepted."""
+        mock_db = Mock()
+        
+        # Mock spot exists and no existing rating
+        mock_spot = Mock()
+        mock_spot.id = 1
+        mock_spot.slug = "test-spot"
+        
+        # Mock successful database operations
+        mock_db.add.return_value = None
+        mock_db.commit.return_value = None
+        mock_db.refresh.return_value = None
+        
+        app.dependency_overrides[get_db] = lambda: mock_db
+        
+        try:
+            # Test "accurate" rating
+            mock_db.query.return_value.filter.return_value.first.side_effect = [
+                mock_spot, None,  # For first test
+            ]
+            
+            data_accurate = self.valid_rating_data.copy()
+            data_accurate["rating"] = "accurate"
+            
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=data_accurate,
+                cookies={"surfe-diem-session-id": "test-session-1"}
+            )
+            assert response.status_code == 200
+            
+            # Reset mocks for second test
+            mock_db.reset_mock()
+            mock_db.query.return_value.filter.return_value.first.side_effect = [
+                mock_spot, None   # For second test
+            ]
+            mock_db.add.return_value = None
+            mock_db.commit.return_value = None
+            mock_db.refresh.return_value = None
+            
+            # Test "not_accurate" rating
+            data_not_accurate = self.valid_rating_data.copy()
+            data_not_accurate["rating"] = "not_accurate"
+            
+            response = self.client.post(
+                "/api/v1/spots/1/rating",
+                json=data_not_accurate,
+                cookies={"surfe-diem-session-id": "test-session-2"}
+            )
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.clear()


### PR DESCRIPTION
Created the spot ratings endpoint `/spots/:id/rating`. 

Adds metadata provided by users on if a spots day forecast (displayed on the webapp) is accurate. Forecast is added as a JSON string.

Data will be community provided, so it might be trash. We will analyze it later.

Rate limits implemented with session ids and ip addresses. We only want one review per day for now.

Sample req body

```
{
  "spot_id": 1,
  "spot_slug": "your-spot-slug",
  "rating": "accurate",
  "forecast_json": {
    "wave_height": "2ft",
    "wind": "5mph"
  },
  "timestamp": "2025-09-18T12:00:00",
  "session_id": "test-session-123",
  "ip_address": "127.0.0.1",
  "user_id": null
}
```
